### PR TITLE
Expanded crawling

### DIFF
--- a/scrape_right/scrape_right/settings.py
+++ b/scrape_right/scrape_right/settings.py
@@ -27,9 +27,9 @@ ROBOTSTXT_OBEY = True
 # Configure a delay for requests for the same website (default: 0)
 # See http://scrapy.readthedocs.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-#DOWNLOAD_DELAY = 3
+DOWNLOAD_DELAY = 3
 # The download delay setting will honor only one of:
-#CONCURRENT_REQUESTS_PER_DOMAIN = 16
+CONCURRENT_REQUESTS_PER_DOMAIN = 8
 #CONCURRENT_REQUESTS_PER_IP = 16
 
 # Disable cookies (enabled by default)
@@ -70,16 +70,16 @@ ROBOTSTXT_OBEY = True
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
-#AUTOTHROTTLE_ENABLED = True
-# The initial download delay
-#AUTOTHROTTLE_START_DELAY = 5
-# The maximum download delay to be set in case of high latencies
-#AUTOTHROTTLE_MAX_DELAY = 60
-# The average number of requests Scrapy should be sending in parallel to
-# each remote server
-#AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
-# Enable showing throttling stats for every response received:
-#AUTOTHROTTLE_DEBUG = False
+# AUTOTHROTTLE_ENABLED = True
+# # The initial download delay
+# AUTOTHROTTLE_START_DELAY = 5
+# # The maximum download delay to be set in case of high latencies
+# AUTOTHROTTLE_MAX_DELAY = 60
+# # The average number of requests Scrapy should be sending in parallel to
+# # each remote server
+# AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
+# # Enable showing throttling stats for every response received:
+# AUTOTHROTTLE_DEBUG = True
 
 # Enable and configure HTTP caching (disabled by default)
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings

--- a/scrape_right/scrape_right/settings.py
+++ b/scrape_right/scrape_right/settings.py
@@ -27,13 +27,14 @@ ROBOTSTXT_OBEY = True
 # Configure a delay for requests for the same website (default: 0)
 # See http://scrapy.readthedocs.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-DOWNLOAD_DELAY = 3
+DOWNLOAD_DELAY = 0.25
 # The download delay setting will honor only one of:
 CONCURRENT_REQUESTS_PER_DOMAIN = 8
 #CONCURRENT_REQUESTS_PER_IP = 16
 
 # Disable cookies (enabled by default)
-#COOKIES_ENABLED = False
+# COOKIES_ENABLED = True
+# COOKIES_DEBUG = True
 
 # Disable Telnet Console (enabled by default)
 #TELNETCONSOLE_ENABLED = False
@@ -70,16 +71,16 @@ CONCURRENT_REQUESTS_PER_DOMAIN = 8
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
-# AUTOTHROTTLE_ENABLED = True
+AUTOTHROTTLE_ENABLED = True
 # # The initial download delay
-# AUTOTHROTTLE_START_DELAY = 5
+AUTOTHROTTLE_START_DELAY = 5
 # # The maximum download delay to be set in case of high latencies
-# AUTOTHROTTLE_MAX_DELAY = 60
+AUTOTHROTTLE_MAX_DELAY = 60
 # # The average number of requests Scrapy should be sending in parallel to
 # # each remote server
-# AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
+AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
 # # Enable showing throttling stats for every response received:
-# AUTOTHROTTLE_DEBUG = True
+AUTOTHROTTLE_DEBUG = True
 
 # Enable and configure HTTP caching (disabled by default)
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings

--- a/scrape_right/scrape_right/spiders/breitbart_spider.py
+++ b/scrape_right/scrape_right/spiders/breitbart_spider.py
@@ -15,49 +15,56 @@ class BreitbartSpider(scrapy.Spider):
 
     def parse_url(self, response):
         '''Parse top nav bar for major categories. Schedule requests to each category
-        landing page and call parse_landing_page'''
-
-        for item in response.xpath('//li/a'):
-            category = item.xpath('@href').extract_first()
-            yield scrapy.Request(response.urljoin(category),
-                                 callback=self.parse_landing_page)
-
-    def parse_landing_page(self, response):
-        '''Parse main page looking for articles. Schedule requests article URL
-        and parse with parse_article
+        landing page and call parse_landing_page
         '''
 
-        # parse links on front page
+        # Menu bar found at top of page contains sub-sections of site
+        menu_bar = response.xpath('//ul[contains(@class, "menu")]')[0:2]  # bottom bar is duplicate
+        for menu in menu_bar:
+            category_list = menu.xpath('.//a/@href').extract()
+            for category in category_list:
+                yield scrapy.Request(response.urljoin(category),
+                                     callback=self.parse_landing_page)
+
+    def parse_landing_page(self, response):
+        '''Parse landing page looking for articles. Schedule requests to article URL
+        and submit to parse_article
+        '''
+
+        # search landing page for articles
         for article in response.xpath('//article/a'):
             article_url = article.xpath('@href').extract_first()
             yield scrapy.Request(response.urljoin(article_url),
                                  callback=self.parse_article)
-        # get links from top nav bar
 
     def parse_article(self, response):
-        '''Main function for parsing articles. Takes response from parse_homepage
-        and yields Article item'''
+        '''Main function for parsing articles. Takes article URLS and yields
+        Article item
+        '''
 
         # Limit to main article body to avoid tag conflicts with other portions of page
         page = response.xpath('//div[contains(@id, "MainW")]')
 
         # Helper function to combine lead plus text body into one string
         def get_text_blob(page):
+
+            # this is the lead
             if page.xpath('//h2/text()').extract_first():
                 blob = page.xpath('//h2/text()').extract_first()
+            # no lead
             else:
                 blob = ''
+
             for text in page.xpath('//p/text()'):
                 blob = blob + text.extract()
             return blob
 
-        # Create and return article item
         article = Article(
-            language=response.xpath('/html/@lang').extract(),
+            language=response.xpath('/html/@lang').extract_first(),
             url=response.url,
             authors=page.xpath('//a[contains(@class, "byauthor")]/text()').extract_first(),
-            pub_datetime=page.xpath('//time[contains(@class, "published")]/@datetime').extract(),
-            modified_datetime=page.xpath('//time[contains(@class, "modified")]/@datetime').extract(),
+            pub_datetime=page.xpath('//time[contains(@class, "published")]/@datetime').extract_first(),
+            modified_datetime=page.xpath('//time[contains(@class, "modified")]/@datetime').extract_first(),
             title=page.xpath('//h1[contains(@itemprop, "headline")]/text()').extract_first(),
             lead=page.xpath('//h2/text()').extract_first(),
             text_blob=get_text_blob(page),


### PR DESCRIPTION
Update settings to allow for auto throttle and minimum of .25 second delay. (I was getting a lot of 503's when parsing full site.

Breitbart spider will now parse all active articles.